### PR TITLE
Update to Visual Tool and Node Server

### DIFF
--- a/Visual Tool/POC/index.html
+++ b/Visual Tool/POC/index.html
@@ -19,8 +19,8 @@
 
 
 <!--Vendor Imports-->
-    <script type="text/javascript" src="resources/vendor/ext-all-debug.js"></script>
-<!--    <script type="text/javascript" src="resources/vendor/ext-all.js"></script>-->
+<!--    <script type="text/javascript" src="resources/vendor/ext-all-debug.js"></script>-->
+    <script type="text/javascript" src="resources/vendor/ext-all.js"></script>
     <script src="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"></script>
     <script type="text/javascript" src="resources/vendor/charts.js"></script>
 	

--- a/Visual Tool/POC/resources/app/analytics_panel.js
+++ b/Visual Tool/POC/resources/app/analytics_panel.js
@@ -29,6 +29,7 @@ Ext.define("analytics_panel", {
                 width: "30%",
                 collapsible: true,
                 split: true,
+                html: '',
                 items: []
 
             }),

--- a/Visual Tool/POC/resources/app/center_piechart.js
+++ b/Visual Tool/POC/resources/app/center_piechart.js
@@ -56,7 +56,7 @@ Ext.define("center_piechart",{
         tooltip: {
             trackMouse: true,
             renderer: function(storeItem, item) {
-                this.setHtml(storeItem.get('os') + ': ' + storeItem.get('data1') + '%');
+//                this.setHtml(storeItem.get('os') + ': ' + storeItem.get('data1') + '%');
             }
         }
     }]

--- a/httpServer/server.js
+++ b/httpServer/server.js
@@ -44,15 +44,37 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     var app = express();
     console.log("Loading FS");
     var fs = require("fs");
-    console.log("SQLITE3");
+    console.log("Loading SQLITE3: ");
     var dblite = require('sqlite3').verbose();
     var dbLocation = "HPTSERVER.db";
-    console.log("Looking for DB at location: " + dbLocation);
+    console.log("Looking for DB at Location: " + dbLocation);
     var dbExists = fs.existsSync(dbLocation);
 //    var resultObject = {"success": "", "rows": [], totalCount: 0};
     
     if(dbExists){
         app.get('/plugins', function (req, res) {
+            console.log("Plugins Total Accessed");
+            console.log("Opening DB at location: " + dbLocation);
+            var db = new dblite.Database(dbLocation);
+            var resultObject = {"success": true, "rows": [], totalCount: 0};
+            var pluginObject = {"value": "", "count": 0};
+            var pluginList = [];
+            
+            var getPlugins = function (err, row) {
+                pluginList.push(row.value);
+            };
+            
+            var setTotalCount = function (err, row) {
+                resultObject.totalCount = row.count;  
+            };
+            
+            db.serialize(function(){
+                db.all("Select * from plugins", getPlugins);
+                
+            });
+        });
+        
+        app.get('/', function (req, res) {
             console.log("Plugins Accessed");
             console.log("Opening DB at location: " + dbLocation);
             var db = new dblite.Database(dbLocation);
@@ -82,19 +104,27 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
         app.get('/plugins/:id', function (req, res) {
             //get plugin table :id 
+            console.log("Opening DB at location: " + dbLocation);
             var db = new dblite.Database(dbLocation);
-            console.log("Sever Pluggins Accessed From " + req.params.id);
+            console.log("Plugin Table " + req.params.id + " Accessed");
+            db.serialize(function(){
+
+            });
+            res.jsonp({name: req.params.id});
             db.close();
-            res.jsonp({name: req.params.id})
         });
 
 
         app.get('/plugins/:id/features', function (req, res) {
             //get plugin table :id Table Data
+            console.log("Opening DB at location: " + dbLocation);
             var db = new dblite.Database(dbLocation);
             console.log("Sever Table " + req.params.id + "from IP " + req.ip);
-            db.close();w
-            res.jsonp({name: req.params.id})
+            db.serialize(function(){
+
+            });
+            res.jsonp({name: req.params.id});
+            db.close();
         });
 
 

--- a/httpServer/server.js
+++ b/httpServer/server.js
@@ -28,15 +28,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (function () {
     'use strict';
-    console.log("                       _________                        __________   \\      /      __________    ____________   ____________");
-    console.log("       /      /       /        /        /|       /     /              \\    /      /         /   /           /       /");
-    console.log("      /      /       /        /        / |      /     /                \\  /      /         /   /           /       /");
-    console.log("     /      /       /        /        /  |     /     /                  \\/      /         /   /           /       /");
-    console.log("    /______/       /        /        /   |    /     /----------         /      /_________/   /           /       /");
-    console.log("   /      /       /        /        /    |   /     /                   /      /             /           /       /");
-    console.log("  /      /       /        /        /     |  /     /                   /      /             /           /       /");
-    console.log(" /      /       /        /        /      | /     /                   /      /             /           /       /");
-    console.log("/      /       /________/        /       |/     /___________        /      /             /___________/       /");
+    console.info("                       _________                        __________   \\      /      __________    ____________   ____________");
+    console.info("       /      /       /        /        /|       /     /              \\    /      /         /   /           /       /");
+    console.info("      /      /       /        /        / |      /     /                \\  /      /         /   /           /       /");
+    console.info("     /      /       /        /        /  |     /     /                  \\/      /         /   /           /       /");
+    console.info("    /______/       /        /        /   |    /     /----------         /      /_________/   /           /       /");
+    console.info("   /      /       /        /        /    |   /     /                   /      /             /           /       /");
+    console.info("  /      /       /        /        /     |  /     /                   /      /             /           /       /");
+    console.info(" /      /       /        /        /      | /     /                   /      /             /           /       /");
+    console.info("/      /       /________/        /       |/     /___________        /      /             /___________/       /");
     
     console.log("Loading HoneyPot Server..........");
     console.log("Loading Express");
@@ -58,21 +58,40 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             console.log("Opening DB at location: " + dbLocation);
             var db = new dblite.Database(dbLocation);
             var resultObject = {"success": true, "rows": [], totalCount: 0};
-            var pluginObject = {"value": "", "count": 0};
+            var pluginObject = {"value":"", "display":"",  "count": 0};
             var pluginList = [];
+            
+            var finish = function() {
+                db.close();
+                res.jsonp({"rows": pluginList});
+                console.log("close");
+            };
+            
+            var addToObject = function (err, row) {
+                pluginList.push({"value": row.value, "display": row.display})  
+            };
+            
             
             var getPlugins = function (err, row) {
                 pluginList.push(row.value);
-            };
-            
-            var setTotalCount = function (err, row) {
-                resultObject.totalCount = row.count;  
+                this.row = row;
+                var me = this;
+                console.log("row", row.value);
+                db.get("Select COUNT(*) from ?", row.value, function (err, row) {
+                    console.log("row", row);
+//                        pluginList.push({"count": row.count});
+                });
             };
             
             db.serialize(function(){
-                db.all("Select * from plugins", getPlugins);
+                db.each("Select * from plugins", getPlugins);
+                db.get("Select * from plugins", finish)
+                
                 
             });
+            
+            
+            
         });
         
         app.get('/', function (req, res) {
@@ -97,12 +116,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             
             db.serialize(function(){
                 
-                db.get("select COUNT(*) as count from plugins", setTotalCount);
+                db.get("Select COUNT(*) as count from plugins", setTotalCount);
                 db.all("Select * from plugins", selectCB);
 
             });
         });
-
+        
         app.get('/plugins/:id', function (req, res) {
             //get plugin table :id 
             console.log("Opening DB at location: " + dbLocation);
@@ -124,7 +143,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             db.serialize(function(){
 
             });
-            res.jsonp({name: req.params.id});
+            res.jsonp({name: req.params.id, feature: "GEOFEATURE"});
             db.close();
         });
 


### PR DESCRIPTION
I updated the visual tool to use the small version of the ext lib.  This will reduce load times.  If a more verbose error output is needed load ext-all-debug instead.  

Changed some routes on Node server to better reflect the tables that will be created in the DB.  