### PR TITLE
Set timeout on socket to end telnet negotiation

### DIFF
--- a/plugins/telnet_plugin.py
+++ b/plugins/telnet_plugin.py
@@ -117,6 +117,7 @@ class Plugin:
         # once negotiations end, begin to read information
         # while loop for negotiations
         # 252 is 'will not'
+        passed_socket.settimeout(4)
         try:
             while True:  # may need to create a flag
                 raw_input = passed_socket.recv(1)
@@ -130,8 +131,7 @@ class Plugin:
                     else:
                         option = passed_socket.recv(1)
                         passed_socket.sendall(255, 252, option)
-        except TypeError:
-            print 'not valid type'
+        except socket.timeout:
             passed_socket.sendall("\n")
             return
 

--- a/plugins/telnet_plugin.py
+++ b/plugins/telnet_plugin.py
@@ -133,6 +133,7 @@ class Plugin:
                         passed_socket.sendall(255, 252, option)
         except socket.timeout:
             passed_socket.sendall("\n")
+            passed_socket.settimeout(35)
             return
 
     def get_port(self):

--- a/plugins/telnet_plugin.py
+++ b/plugins/telnet_plugin.py
@@ -130,7 +130,9 @@ class Plugin:
                         continue
                     else:
                         option = passed_socket.recv(1)
-                        passed_socket.sendall(255, 252, option)
+                        passed_socket.sendall(chr(255))
+                        passed_socket.sendall(chr(252))
+                        passed_socket.sendall(chr(option))
         except socket.timeout:
             passed_socket.sendall("\n")
             return

--- a/plugins/telnet_plugin.py
+++ b/plugins/telnet_plugin.py
@@ -130,7 +130,6 @@ class Plugin:
                         option = passed_socket.recv(1)
                         passed_socket.sendall(chr(255) + chr(252) + option)
         except socket.timeout:
-            passed_socket.sendall("\n")
             return
 
     def get_port(self):

--- a/plugins/telnet_plugin.py
+++ b/plugins/telnet_plugin.py
@@ -120,19 +120,15 @@ class Plugin:
         # 252 is 'will not'
         try:
             while True:  # may need to create a flag
-                raw_input = passed_socket.recv(1)
-                byte = ord(raw_input)
-                if byte != 255:
+                if ord(passed_socket.recv(1)) != 255:
                     continue
                 else:
-                    verb = passed_socket.recv(1)
+                    verb = ord(passed_socket.recv(1))
                     if verb != 251 & verb != 253:
                         continue
                     else:
                         option = passed_socket.recv(1)
-                        passed_socket.sendall(chr(255))
-                        passed_socket.sendall(chr(252))
-                        passed_socket.sendall(chr(option))
+                        passed_socket.sendall(chr(255) + chr(252) + option)
         except socket.timeout:
             passed_socket.sendall("\n")
             return

--- a/plugins/telnet_plugin.py
+++ b/plugins/telnet_plugin.py
@@ -56,9 +56,10 @@ class Plugin:
         
         self.time_stamp = datetime.datetime.now()
         logging.info(self.time_stamp)
-        passed_socket.settimeout(35)
-        if socket:
+        if passed_socket:
+            passed_socket.settimeout(4)
             self.negotiate(passed_socket)
+            passed_socket.settimeout(35)
             passed_socket.sendall("login as: ")
             try:
                 username = passed_socket.recv(4096)
@@ -117,7 +118,6 @@ class Plugin:
         # once negotiations end, begin to read information
         # while loop for negotiations
         # 252 is 'will not'
-        passed_socket.settimeout(4)
         try:
             while True:  # may need to create a flag
                 raw_input = passed_socket.recv(1)
@@ -133,7 +133,6 @@ class Plugin:
                         passed_socket.sendall(255, 252, option)
         except socket.timeout:
             passed_socket.sendall("\n")
-            passed_socket.settimeout(35)
             return
 
     def get_port(self):


### PR DESCRIPTION
@coyle5280 So the telnet plugin keeps reading from the socket during negotiation, looking for options requested by the client. A timeout is set on the socket, and we assume the client is done negotiating once a read times out. What do you think about four seconds for the timeout?

@ckaz18 Please look this over, let me know if you have any thoughts.